### PR TITLE
No more removing extensions from directory names #22

### DIFF
--- a/src/databricksApi/workspaces/DatabricksWorkspaceDirectory.ts
+++ b/src/databricksApi/workspaces/DatabricksWorkspaceDirectory.ts
@@ -125,15 +125,19 @@ export class DatabricksWorkspaceDirectory extends DatabricksWorkspaceTreeItem {
 
 			for (let local of localContent) {
 				let localFile: fspath.ParsedPath = fspath.parse(local);
-				let localRelativePath = (this.path + '/'
-					+ localFile.base.replace(LanguageFileExtensionMapper.extensionFromFileName(localFile.base), '')) // remove extension
-					.replace('//', '/');
 				let localFullPath = fspath.join(this.localPath, local);
+				let shownLocalFile = localFile.base;
+				let isFile = fs.lstatSync(localFullPath).isFile();
+				if (isFile) // remove extension
+				{
+					shownLocalFile = shownLocalFile.replace(LanguageFileExtensionMapper.extensionFromFileName(shownLocalFile), '');
+				}
+				let localRelativePath = (this.path + '/' + shownLocalFile).replace('//', '/');
 
 				if (!onlinePaths.includes(localRelativePath)) {
 					let languageFileExtension: LanguageFileExtensionMapper = undefined;
 
-					if (fs.lstatSync(localFullPath).isFile()) {
+					if (isFile) {
 						let ext = LanguageFileExtensionMapper.extensionFromFileName(localFile.base);
 
 						if (LanguageFileExtensionMapper.supportedFileExtensions.includes(ext)


### PR DESCRIPTION
Previously, when . was present in directory name, the part after last dot was removed.

This lead to duplicate entries in workspace browser.

Now extensions is removed only for actual files.