### PR TITLE
Added proper default options for Azure connection

### DIFF
--- a/src/vscode/treeviews/connections/DatabricksConnectionManagerAzure.ts
+++ b/src/vscode/treeviews/connections/DatabricksConnectionManagerAzure.ts
@@ -103,7 +103,13 @@ export class DatabricksConnectionManagerAzure extends DatabricksConnectionManage
 		}
 
 		try {
-			let session: vscode.AuthenticationSession = await vscode.authentication.getSession("microsoft", scopes);
+			let options: vscode.AuthenticationGetSessionOptions = {
+				clearSessionPreference: false,
+				createIfNone: true,
+				forceNewSession: false,
+				silent: false
+			}
+			let session: vscode.AuthenticationSession = await vscode.authentication.getSession("microsoft", scopes, options);
 			return session;
 		}
 		catch (e) {

--- a/src/vscode/treeviews/connections/DatabricksConnectionManagerAzure.ts
+++ b/src/vscode/treeviews/connections/DatabricksConnectionManagerAzure.ts
@@ -103,13 +103,7 @@ export class DatabricksConnectionManagerAzure extends DatabricksConnectionManage
 		}
 
 		try {
-			let options: vscode.AuthenticationGetSessionOptions = {
-				clearSessionPreference: false,
-				createIfNone: true,
-				forceNewSession: false,
-				silent: false
-			}
-			let session: vscode.AuthenticationSession = await vscode.authentication.getSession("microsoft", scopes, options);
+			let session: vscode.AuthenticationSession = await vscode.authentication.getSession("microsoft", scopes, { createIfNone: true });
 			return session;
 		}
 		catch (e) {


### PR DESCRIPTION
Hi @gbrueckl,

Thanks for this great extension, we use it daily in our company!

Recently we had to switch from PAT to Azure Login, and I encountered some errors with the Azure Login type, and was able to boil it down to the default options of the `vscode.AuthenticationGetSessionOptions`. I needed to set the `createIfNone` option to `true`, otherwise no session will be created in our case. I left all the other values set to their default value `false`. I think we can leave the option `createIfNone` on `true` since it seems like a sensible default value for everyone, but we can also create an option in the workspace settings.

Let me know what you think :)

Best regards
Chris