### PR TITLE
Updating Jobs Link

### DIFF
--- a/src/vscode/treeviews/jobs/DatabricksJob.ts
+++ b/src/vscode/treeviews/jobs/DatabricksJob.ts
@@ -72,7 +72,7 @@ export class DatabricksJob extends DatabricksJobTreeItem {
 
 	get link(): string {
 		let actConn = ThisExtension.ActiveConnection;
-		let link: string = Helper.trimChar(FSHelper.joinPathSync(actConn.apiRootUrl, "?#job", this.job_id.toString()).toString(true), '/');
+		let link: string = Helper.trimChar(FSHelper.joinPathSync(actConn.apiRootUrl, "jobs", this.job_id.toString()).toString(true), '/');
 		
 		return link;
 	}


### PR DESCRIPTION
The link to the Jobs via the panel on the side was directing to: `https://<workspace_url>/%253F%2523job/<job_id>`

It should be: `https://<workspace_url>/jobs/<job_id>`